### PR TITLE
Add sample GDAL test plugin for QGIS 3.28

### DIFF
--- a/gdal_test_plugin/__init__.py
+++ b/gdal_test_plugin/__init__.py
@@ -1,0 +1,6 @@
+from .gdal_test_plugin import GdalTestPlugin
+
+
+def classFactory(iface):
+    """QGIS calls this function to instantiate the plugin."""
+    return GdalTestPlugin(iface)

--- a/gdal_test_plugin/gdal_test_dialog.py
+++ b/gdal_test_plugin/gdal_test_dialog.py
@@ -1,0 +1,63 @@
+import os
+from qgis.PyQt.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QPushButton,
+    QFileDialog,
+    QMessageBox,
+)
+from qgis.PyQt.QtCore import Qt
+try:
+    from osgeo import gdal
+except Exception:  # pragma: no cover - handled at runtime
+    gdal = None
+
+
+class GdalTestDialog(QDialog):
+    """Dialog with a single button to test GDAL."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("GDAL Test")
+        layout = QVBoxLayout()
+        self.button = QPushButton("Run GDAL")
+        layout.addWidget(self.button)
+        self.setLayout(layout)
+        self.button.clicked.connect(self.run_gdal)
+
+    def run_gdal(self):
+        if gdal is None:
+            QMessageBox.critical(self, "GDAL", "GDAL library is not available")
+            return
+
+        input_path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Select raster",
+            "",
+            "Raster files (*.*)",
+        )
+        if not input_path:
+            return
+        try:
+            ds = gdal.Open(input_path)
+            if ds is None:
+                QMessageBox.warning(self, "GDAL", "Unable to open selected file")
+                return
+            output_path, _ = QFileDialog.getSaveFileName(
+                self,
+                "Save copy",
+                os.path.join(os.path.dirname(input_path), "gdal_copy.tif"),
+                "GeoTIFF (*.tif)",
+            )
+            if not output_path:
+                return
+            gdal.Translate(output_path, ds)
+            QMessageBox.information(
+                self,
+                "GDAL",
+                f"Dataset copied to:\n{output_path}",
+                QMessageBox.Ok,
+                QMessageBox.Ok,
+            )
+        except Exception as exc:
+            QMessageBox.critical(self, "GDAL error", str(exc))

--- a/gdal_test_plugin/gdal_test_plugin.py
+++ b/gdal_test_plugin/gdal_test_plugin.py
@@ -1,0 +1,31 @@
+import os
+from qgis.PyQt.QtWidgets import QAction
+from qgis.PyQt.QtGui import QIcon
+from .gdal_test_dialog import GdalTestDialog
+
+
+class GdalTestPlugin:
+    """Simple plugin demonstrating GDAL usage from QGIS."""
+
+    def __init__(self, iface):
+        self.iface = iface
+        self.action = None
+        self.dialog = None
+
+    def initGui(self):
+        icon_path = os.path.join(os.path.dirname(__file__), "icon.svg")
+        self.action = QAction(QIcon(icon_path), "GDAL Test", self.iface.mainWindow())
+        self.action.triggered.connect(self.run)
+        self.iface.addToolBarIcon(self.action)
+
+    def unload(self):
+        if self.action:
+            self.iface.removeToolBarIcon(self.action)
+            self.action.deleteLater()
+
+    def run(self):
+        if not self.dialog:
+            self.dialog = GdalTestDialog(self.iface.mainWindow())
+        self.dialog.show()
+        self.dialog.raise_()
+        self.dialog.activateWindow()

--- a/gdal_test_plugin/icon.svg
+++ b/gdal_test_plugin/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+  <rect width="16" height="16" fill="#4b0082"/>
+  <text x="8" y="12" font-size="12" text-anchor="middle" fill="#ffffff">G</text>
+</svg>

--- a/gdal_test_plugin/metadata.txt
+++ b/gdal_test_plugin/metadata.txt
@@ -1,0 +1,9 @@
+[general]
+name=GDAL Test Plugin
+description=Plugin de prueba que muestra la lectura y copia de datos raster usando GDAL.
+version=1.0
+qgisMinimumVersion=3.28
+author=OpenAI Assistant
+email=noreply@example.com
+about=Plugin de prueba para QGIS 3.28 LTR que ejecuta operaciones simples de GDAL sin modificar los archivos originales.
+icon=icon.svg


### PR DESCRIPTION
## Summary
- provide a minimal QGIS plugin with PyQt5 GUI
- plugin button opens dialog to read a raster via GDAL and save a copy
- include metadata and SVG icon for plugin registration

## Testing
- `python -m py_compile gdal_test_plugin/*.py`
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f4a09cea4832181eddd974c5002c0