### PR TITLE
Add GDAL color relief demo plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 Desarrollo de software plugin para QGIS 3.28 LTR STANDALONE haciendo uso de GDAL.
+
+El repositorio incluye ahora dos plugins de ejemplo:
+
+* `gdal_test_plugin`: copia rasters seleccionados utilizando GDAL.
+* `gdal_color_relief_plugin`: aplica una rampa de color a un DEM mediante GDAL.
 <img width="1366" height="705" alt="image" src="https://github.com/user-attachments/assets/34693439-5029-4584-a065-bb66300def42" />
 
 

--- a/gdal_color_relief_plugin/__init__.py
+++ b/gdal_color_relief_plugin/__init__.py
@@ -1,0 +1,6 @@
+from .color_relief_plugin import ColorReliefPlugin
+
+
+def classFactory(iface):
+    """QGIS calls this function to instantiate the plugin."""
+    return ColorReliefPlugin(iface)

--- a/gdal_color_relief_plugin/color_relief_dialog.py
+++ b/gdal_color_relief_plugin/color_relief_dialog.py
@@ -1,0 +1,84 @@
+import os
+import tempfile
+
+from qgis.PyQt.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QPushButton,
+    QFileDialog,
+    QMessageBox,
+)
+
+try:
+    from osgeo import gdal
+except Exception:  # pragma: no cover - handled at runtime
+    gdal = None
+
+
+class ColorReliefDialog(QDialog):
+    """Apply a simple color relief to a DEM using GDAL."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("DEM Color Relief")
+        layout = QVBoxLayout()
+        self.button = QPushButton("Colorize DEM")
+        layout.addWidget(self.button)
+        self.setLayout(layout)
+        self.button.clicked.connect(self.run_color_relief)
+
+    def run_color_relief(self):
+        if gdal is None:
+            QMessageBox.critical(self, "GDAL", "GDAL library is not available")
+            return
+
+        input_path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Select DEM",
+            "",
+            "Raster files (*.tif *.img *.hdr *.asc *.*)",
+        )
+        if not input_path:
+            return
+
+        output_path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save color relief",
+            os.path.join(os.path.dirname(input_path), "color_relief.tif"),
+            "GeoTIFF (*.tif)",
+        )
+        if not output_path:
+            return
+
+        try:
+            with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+                tmp.write(
+                    "0 0 0 255\n"
+                    "500 0 255 0\n"
+                    "1000 255 255 0\n"
+                    "2000 255 0 0\n"
+                )
+                color_file = tmp.name
+
+            gdal.DEMProcessing(
+                output_path,
+                input_path,
+                "color-relief",
+                colorFilename=color_file,
+            )
+
+            QMessageBox.information(
+                self,
+                "GDAL",
+                f"Color relief saved to:\n{output_path}",
+                QMessageBox.Ok,
+                QMessageBox.Ok,
+            )
+        except Exception as exc:
+            QMessageBox.critical(self, "GDAL error", str(exc))
+        finally:
+            try:
+                os.remove(color_file)
+            except Exception:
+                pass
+

--- a/gdal_color_relief_plugin/color_relief_plugin.py
+++ b/gdal_color_relief_plugin/color_relief_plugin.py
@@ -1,0 +1,34 @@
+import os
+
+from qgis.PyQt.QtWidgets import QAction
+from qgis.PyQt.QtGui import QIcon
+
+from .color_relief_dialog import ColorReliefDialog
+
+
+class ColorReliefPlugin:
+    """Generate a colorized raster from a DEM using GDAL."""
+
+    def __init__(self, iface):
+        self.iface = iface
+        self.action = None
+        self.dialog = None
+
+    def initGui(self):
+        icon_path = os.path.join(os.path.dirname(__file__), "icon.svg")
+        self.action = QAction(QIcon(icon_path), "DEM Color Relief", self.iface.mainWindow())
+        self.action.triggered.connect(self.run)
+        self.iface.addToolBarIcon(self.action)
+
+    def unload(self):
+        if self.action:
+            self.iface.removeToolBarIcon(self.action)
+            self.action.deleteLater()
+
+    def run(self):
+        if not self.dialog:
+            self.dialog = ColorReliefDialog(self.iface.mainWindow())
+        self.dialog.show()
+        self.dialog.raise_()
+        self.dialog.activateWindow()
+

--- a/gdal_color_relief_plugin/icon.svg
+++ b/gdal_color_relief_plugin/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
+  <rect width="16" height="16" fill="#4b0082"/>
+  <text x="8" y="12" font-size="12" text-anchor="middle" fill="#ffffff">G</text>
+</svg>

--- a/gdal_color_relief_plugin/metadata.txt
+++ b/gdal_color_relief_plugin/metadata.txt
@@ -1,0 +1,9 @@
+[general]
+name=DEM Color Relief
+description=Aplica una rampa de color a un DEM usando GDAL.
+version=1.0
+qgisMinimumVersion=3.28
+author=OpenAI Assistant
+email=noreply@example.com
+about=Genera un raster a color a partir de un DEM para facilitar la visualización.
+icon=icon.svg


### PR DESCRIPTION
## Summary
- add `gdal_color_relief_plugin` to generate a colorized DEM using GDAL
- update README to document both sample plugins

## Testing
- `python -m py_compile gdal_color_relief_plugin/*.py && echo "py_compile ok"`


------
https://chatgpt.com/codex/tasks/task_e_689f4c1d79808321b9c1320278964af1