### PR TITLE
Normalize streamFile path in burnStream

### DIFF
--- a/QSWATPlus/QSWATTopology.py
+++ b/QSWATPlus/QSWATTopology.py
@@ -4040,6 +4040,7 @@ class QSWATTopology:
         demReduction = float(depth) / verticalFactor
 
         # ensure output directory exists
+        streamFile = os.path.normpath(streamFile)
         demFile = os.path.normpath(demFile)
         burnFile = os.path.normpath(burnFile)
         burnDir = os.path.normpath(os.path.dirname(burnFile))


### PR DESCRIPTION
## Summary
- Normalize `streamFile` path in `QSWATTopology.burnStream` to avoid mixed separators.
- Confirm `QgsVectorLayer` inputs build paths via `QSWATUtils.join` or `os.path` for consistency.

## Testing
- `python -m py_compile QSWATPlus/QSWATTopology.py`


------
https://chatgpt.com/codex/tasks/task_e_689f6e459d288321a97f2a6d18d4847b