### PR TITLE
Log GDAL errors and validate burned DEM

### DIFF
--- a/QSWATPlus/QSWATTopology.py
+++ b/QSWATPlus/QSWATTopology.py
@@ -4072,12 +4072,17 @@ class QSWATTopology:
             burnDs = driver.CreateCopy(burnFile, demDs, 0)
         except RuntimeError as e:
             QSWATUtils.error(f'Failed to copy DEM from {demFile} to {burnFile}: {e}', isBatch)
+            lastErr = gdal.GetLastErrorMsg()
+            if lastErr:
+                QSWATUtils.error(lastErr, isBatch)
             demDs = None
+            QSWATUtils.tryRemoveFiles(burnFile)
             return
 
         if burnDs is None:
             QSWATUtils.error(f'Failed to create burned-in DEM {burnFile} from {demFile}', isBatch)
             demDs = None
+            QSWATUtils.tryRemoveFiles(burnFile)
             return
 
         demDs = None

--- a/QSWATPlus/delineation.py
+++ b/QSWATPlus/delineation.py
@@ -1776,8 +1776,19 @@ assumed that its crossing the lake boundary is an inaccuracy.
                 QSWATUtils.tryRemoveLayerAndFiles(burnedDemFile, root)
                 self.progress('Burning streams ...')
                 QSWATTopology.burnStream(burnFile, demFile, burnedDemFile, self._gv.burninDepth, self._gv.verticalFactor, self._gv.isBatch)
-                if not os.path.exists(burnedDemFile):
+                if not os.path.exists(burnedDemFile) or os.path.getsize(burnedDemFile) == 0:
+                    QSWATUtils.error('Failed to create burned in DEM {0}'.format(burnedDemFile), self._gv.isBatch)
+                    QSWATUtils.tryRemoveFiles(burnedDemFile)
                     return
+                try:
+                    testDs = gdal.Open(burnedDemFile)
+                except Exception:
+                    testDs = None
+                if testDs is None:
+                    QSWATUtils.error('Burned in DEM {0} is invalid'.format(burnedDemFile), self._gv.isBatch)
+                    QSWATUtils.tryRemoveFiles(burnedDemFile)
+                    return
+                testDs = None
             self._gv.burnedDemFile = burnedDemFile
             delineationDem = burnedDemFile
         else:


### PR DESCRIPTION
## Summary
- Log GDAL's last error and clean up partial burn files when stream burning fails
- Verify burned DEM file size and validity before proceeding with TauDEM

## Testing
- `python -m py_compile QSWATPlus/QSWATTopology.py QSWATPlus/delineation.py && echo 'py_compile succeeded'`
- `pytest` *(fails: No module named 'PyQt5')*


------
https://chatgpt.com/codex/tasks/task_e_689f82d0da90832186fa57514886a4a2