### PR TITLE
Use normpath when parsing QGIS path

### DIFF
--- a/QSWATPlus/QSWATUtils.py
+++ b/QSWATPlus/QSWATUtils.py
@@ -105,7 +105,7 @@ class QSWATUtils:
         This only seems to work on Windows"""
         try:
             import qgis
-            dirs = qgis.__file__.split('/')  # @UndefinedVariable
+            dirs = os.path.normpath(qgis.__file__).split(os.sep)  # @UndefinedVariable
             for i in range(len(dirs)):
                 if dirs[i] == 'apps':
                     return dirs[i+1]


### PR DESCRIPTION
## Summary
- normalize qgis module path before splitting to derive the QGIS installation name

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'PyQt5')*
- `pip install PyQt5` *(fails: Could not find a version that satisfies the requirement PyQt5)*

------
https://chatgpt.com/codex/tasks/task_e_689f85fda4e083219bb70f0e71a1eb1b