### PR TITLE
Add GDAL CreateCopy test script for debugging

### DIFF
--- a/burn_stream_test.bat
+++ b/burn_stream_test.bat
@@ -1,0 +1,16 @@
+@echo off
+REM Ejecuta burn_stream_test.py con rutas predefinidas
+REM Ajustar si es necesario para otros datos
+
+set "DEM=C:\Users\jhonv\Downloads\robit_data\rasters\srtm_30m\hdr.adf"
+set "BURN=C:\Users\jhonv\Downloads\robit_data\rasters\srtm_30m\hdr_burned.tif"
+REM Archivo de red hídrica (no utilizado en esta prueba de copia)
+set "STREAM=C:\Users\jhonv\Downloads\robit_data\shapefiles\robReach.shp"
+
+REM Ajustar PYTHON_EXE si se requiere el Python de QGIS
+set PYTHON_EXE=python
+"%PYTHON_EXE%" "%~dp0burn_stream_test.py" "%DEM%" "%BURN%"
+
+echo.
+echo Se intentó copiar %DEM% a %BURN%
+pause

--- a/burn_stream_test.py
+++ b/burn_stream_test.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+"""Minimal test for GDAL CreateCopy to replicate burnStream copying step."""
+import sys
+import os
+from osgeo import gdal
+import shutil
+
+
+def main(dem_path: str, burn_path: str) -> int:
+    gdal.UseExceptions()
+    dem_path = os.path.normpath(dem_path)
+    burn_path = os.path.normpath(burn_path)
+
+    dem_ds = gdal.Open(dem_path, gdal.GA_ReadOnly)
+    if dem_ds is None:
+        print(f"Could not open DEM {dem_path}")
+        return 1
+    driver = gdal.GetDriverByName("GTiff")
+    if driver is None:
+        print("GTiff driver not available")
+        return 1
+    try:
+        burn_ds = driver.CreateCopy(burn_path, dem_ds, 0, options=["BIGTIFF=YES"])
+    except RuntimeError as e:
+        print(f"CreateCopy failed: {e}")
+        print(f"GDAL error {gdal.GetLastErrorType()}: {gdal.GetLastErrorMsg()}")
+        print("Attempting shutil.copy as fallback...")
+        try:
+            shutil.copy(dem_path, burn_path)
+            print("Fallback copy succeeded")
+            return 0
+        except Exception as ex:
+            print(f"Fallback copy failed: {ex}")
+            return 1
+    if burn_ds is None:
+        print("CreateCopy returned None")
+        return 1
+    burn_ds = None
+    dem_ds = None
+    print("CreateCopy succeeded")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: burn_stream_test.py <input_dem> <output_dem>")
+        sys.exit(1)
+    sys.exit(main(sys.argv[1], sys.argv[2]))

--- a/copy_dem_test.bat
+++ b/copy_dem_test.bat
@@ -1,0 +1,40 @@
+@echo off
+REM Copia un DEM para probar si GDAL puede crear archivos GeoTIFF
+REM Ajustar las rutas para su entorno antes de ejecutar
+REM DEM original en formato Arc/Info (archivo hdr.adf)
+set "DEM=C:\Users\jhonv\Downloads\robit_data\rasters\srtm_30m\hdr.adf"
+REM Archivo de salida para la copia de prueba
+set "COPIA=C:\Users\jhonv\Downloads\robit_data\rasters\srtm_30m\hdr_copy.tif"
+
+python - <<PY
+import sys
+from osgeo import gdal
+
+dem_file = r"%DEM%"
+copy_file = r"%COPIA%"
+print(f"Copiando {dem_file} a {copy_file}")
+dem = gdal.Open(dem_file, gdal.GA_ReadOnly)
+if dem is None:
+    print("No se pudo abrir el DEM de entrada")
+    sys.exit(1)
+
+driver = gdal.GetDriverByName('GTiff')
+if driver is None:
+    print("No se encontró el driver GTiff")
+    sys.exit(1)
+
+try:
+    gdal.UseExceptions()
+    out = driver.CreateCopy(copy_file, dem, 0)
+except RuntimeError as e:
+    print("Fallo al copiar el DEM:", e)
+    sys.exit(1)
+
+if out is None:
+    print("CreateCopy devolvió None")
+    sys.exit(1)
+else:
+    print("Archivo creado correctamente")
+PY
+
+pause


### PR DESCRIPTION
## Summary
- Add `burn_stream_test.py` to reproduce DEM copy using GDAL and fallback to `shutil.copy`
- Provide `burn_stream_test.bat` and `copy_dem_test.bat` wrappers with sample Arc/Info GRID paths for quick testing

## Testing
- `python -m py_compile burn_stream_test.py`


------
https://chatgpt.com/codex/tasks/task_e_689f8965ad1c83218097da6c714104f7