### PR TITLE
Log burn file removal on failed DEM copy

### DIFF
--- a/QSWATPlus/QSWATTopology.py
+++ b/QSWATPlus/QSWATTopology.py
@@ -4076,12 +4076,14 @@ class QSWATTopology:
             if lastErr:
                 QSWATUtils.error(lastErr, isBatch)
             demDs = None
+            QSWATUtils.information(f'Removing {burnFile} due to failed copy', isBatch)
             QSWATUtils.tryRemoveFiles(burnFile)
             return
 
         if burnDs is None:
             QSWATUtils.error(f'Failed to create burned-in DEM {burnFile} from {demFile}', isBatch)
             demDs = None
+            QSWATUtils.information(f'Removing {burnFile} due to failed creation', isBatch)
             QSWATUtils.tryRemoveFiles(burnFile)
             return
 


### PR DESCRIPTION
## Summary
- Log when deleting burnFile after failed DEM copy
- Log when deleting burnFile if raster creation returns None

## Testing
- `python -m py_compile QSWATPlus/QSWATTopology.py`
- ⚠️ Unable to run full QGIS/GDAL environment to reproduce error, but simulated failure shows expected message


------
https://chatgpt.com/codex/tasks/task_e_689fa98cd620832189e8fb7b167a209c